### PR TITLE
Add container CLI check

### DIFF
--- a/src/petrel/main.py
+++ b/src/petrel/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import hashlib
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -72,8 +73,21 @@ def ensure_container_running(auto_start: bool = True) -> None:
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
-def main() -> None:
+@click.pass_context
+def main(ctx: click.Context) -> None:
     """Petrel CLI entry point."""
+    if shutil.which("container") is None:
+        click.echo(
+            click.style(
+                (
+                    "The 'container' program was not found. Install it first "
+                    "(e.g. `brew install container`)."
+                ),
+                fg="red",
+            ),
+            err=True,
+        )
+        ctx.exit(1)
 
 
 @main.command(name="codex", context_settings={"help_option_names": ["-h", "--help"]})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+import shutil
 import sys
 from pathlib import Path
+
+import pytest
 
 # Ensure src/ is on sys.path for imports
 SRC_PATH = Path(__file__).resolve().parent.parent / "src"
 sys.path.insert(0, str(SRC_PATH))
+
+
+@pytest.fixture(autouse=True)
+def _mock_container_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        shutil,
+        "which",
+        lambda cmd: "/usr/bin/container" if cmd == "container" else None,
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shutil
+
 # ruff: noqa: S101
 import subprocess  # noqa: S404 -- used in testing
 
@@ -148,3 +150,11 @@ def test_cli_build_error_when_not_running(monkeypatch: pytest.MonkeyPatch) -> No
     result = runner.invoke(main, ["build"])
     assert result.exit_code == 1
     assert "Error: failed to start" in result.output
+
+
+def test_cli_error_when_container_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+    runner = CliRunner()
+    result = runner.invoke(main, ["codex"])
+    assert result.exit_code == 1
+    assert "brew install container" in result.output


### PR DESCRIPTION
## Summary
- warn if container CLI isn't installed
- mock the container CLI for tests
- test missing container error message

## Testing
- `uv run ruff format src tests`
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest`
- `uv run pre-commit run --files $(git ls-files)`

------
https://chatgpt.com/codex/tasks/task_e_6869da5c378083329254e05f4a541df4