### PR TITLE
Add image build prompt to codex

### DIFF
--- a/src/petrel/main.py
+++ b/src/petrel/main.py
@@ -183,6 +183,28 @@ def codex(
         click.echo(click.style(f"Error: {exc}", fg="red"), err=True)
         sys.exit(1)
 
+    # Verify that the container image exists; prompt to build if missing.
+    image_check = _run(["container", "images", image], check=False, capture_output=True)
+    if image_check.returncode != 0 or not image_check.stdout.strip():
+        if click.confirm(
+            f"Container image '{image}' not found. Build it now?", default=True
+        ):
+            # Reuse the build command with default template and context
+            build.callback(  # type: ignore[misc]
+                tag=image,
+                dockerfile_template=None,
+                context=Path(),
+                no_auto_start=no_auto_start,
+            )
+        else:
+            click.echo(
+                click.style(
+                    f"Image '{image}' is required but was not built.", fg="red"
+                ),
+                err=True,
+            )
+            sys.exit(1)
+
     # Ensure the persistent directory exists so `--mount src=…` never errors.
     persistent_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/petrel/main.py
+++ b/src/petrel/main.py
@@ -185,9 +185,9 @@ def codex(
 
     # Verify that the container image exists; prompt to build if missing.
     image_check = _run(
-        ["container", "images", "list", image], check=False, capture_output=True
+        ["container", "images", "inspect", image], check=False, capture_output=True
     )
-    if image_check.returncode != 0 or image not in image_check.stdout:
+    if image_check.returncode != 0:
         if click.confirm(
             f"Container image '{image}' not found. Build it now?", default=True
         ):

--- a/src/petrel/main.py
+++ b/src/petrel/main.py
@@ -184,8 +184,10 @@ def codex(
         sys.exit(1)
 
     # Verify that the container image exists; prompt to build if missing.
-    image_check = _run(["container", "images", image], check=False, capture_output=True)
-    if image_check.returncode != 0 or not image_check.stdout.strip():
+    image_check = _run(
+        ["container", "images", "list", image], check=False, capture_output=True
+    )
+    if image_check.returncode != 0 or image not in image_check.stdout:
         if click.confirm(
             f"Container image '{image}' not found. Build it now?", default=True
         ):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -229,8 +229,8 @@ def test_cli_codex_builds_when_image_missing(monkeypatch: pytest.MonkeyPatch) ->
         calls.append(cmd)
         if cmd[:3] == ["container", "system", "status"]:
             return DummyCompleted(stdout="running")
-        if cmd[:2] == ["container", "images"]:
-            return DummyCompleted(stdout="", returncode=1)
+        if cmd[:3] == ["container", "images", "list"]:
+            return DummyCompleted(stdout="")
         if cmd[:2] == ["container", "build"]:
             return DummyCompleted(stdout="")
         raise AssertionError(f"Unexpected command: {cmd}")
@@ -252,8 +252,8 @@ def test_cli_codex_abort_when_image_missing(monkeypatch: pytest.MonkeyPatch) -> 
         _ = check, capture_output
         if cmd[:3] == ["container", "system", "status"]:
             return DummyCompleted(stdout="running")
-        if cmd[:2] == ["container", "images"]:
-            return DummyCompleted(stdout="", returncode=1)
+        if cmd[:3] == ["container", "images", "list"]:
+            return DummyCompleted(stdout="")
         raise AssertionError(f"Unexpected command: {cmd}")
 
     monkeypatch.setattr(main_module, "_run", fake_run)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -229,8 +229,8 @@ def test_cli_codex_builds_when_image_missing(monkeypatch: pytest.MonkeyPatch) ->
         calls.append(cmd)
         if cmd[:3] == ["container", "system", "status"]:
             return DummyCompleted(stdout="running")
-        if cmd[:3] == ["container", "images", "list"]:
-            return DummyCompleted(stdout="")
+        if cmd[:3] == ["container", "images", "inspect"]:
+            return DummyCompleted(stdout="", returncode=1)
         if cmd[:2] == ["container", "build"]:
             return DummyCompleted(stdout="")
         raise AssertionError(f"Unexpected command: {cmd}")
@@ -252,8 +252,8 @@ def test_cli_codex_abort_when_image_missing(monkeypatch: pytest.MonkeyPatch) -> 
         _ = check, capture_output
         if cmd[:3] == ["container", "system", "status"]:
             return DummyCompleted(stdout="running")
-        if cmd[:3] == ["container", "images", "list"]:
-            return DummyCompleted(stdout="")
+        if cmd[:3] == ["container", "images", "inspect"]:
+            return DummyCompleted(stdout="", returncode=1)
         raise AssertionError(f"Unexpected command: {cmd}")
 
     monkeypatch.setattr(main_module, "_run", fake_run)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import os
 import shutil
 
 # ruff: noqa: S101
 import subprocess  # noqa: S404 -- used in testing
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+import click
 
 if TYPE_CHECKING:
     from importlib.resources.abc import Traversable
@@ -214,3 +217,48 @@ def test_cli_error_when_container_missing(monkeypatch: pytest.MonkeyPatch) -> No
     result = runner.invoke(main, ["codex"])
     assert result.exit_code == 1
     assert "brew install container" in result.output
+
+
+def test_cli_codex_builds_when_image_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[list[str]] = []
+
+    def fake_run(
+        cmd: list[str], check: bool = True, capture_output: bool = False
+    ) -> DummyCompleted:
+        _ = check, capture_output
+        calls.append(cmd)
+        if cmd[:3] == ["container", "system", "status"]:
+            return DummyCompleted(stdout="running")
+        if cmd[:2] == ["container", "images"]:
+            return DummyCompleted(stdout="", returncode=1)
+        if cmd[:2] == ["container", "build"]:
+            return DummyCompleted(stdout="")
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(main_module, "_run", fake_run)
+    monkeypatch.setattr(click, "confirm", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(os, "execvp", lambda _prog, _args: None)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["codex"])
+    assert result.exit_code == 0
+    assert any(call[:2] == ["container", "build"] for call in calls)
+
+
+def test_cli_codex_abort_when_image_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_run(
+        cmd: list[str], check: bool = True, capture_output: bool = False
+    ) -> DummyCompleted:
+        _ = check, capture_output
+        if cmd[:3] == ["container", "system", "status"]:
+            return DummyCompleted(stdout="running")
+        if cmd[:2] == ["container", "images"]:
+            return DummyCompleted(stdout="", returncode=1)
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(main_module, "_run", fake_run)
+    monkeypatch.setattr(click, "confirm", lambda *_args, **_kwargs: False)
+
+    runner = CliRunner()
+    result = runner.invoke(main, ["codex"])
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- prompt to build codex image if missing
- test codex image build prompt logic

## Testing
- `uv run ruff format src tests`
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest -q`
- `uv run pre-commit run --files src/petrel/main.py tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_6869e2b5cb448332a59c150c5c7c5082