### PR TITLE
Add version display option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Install Petrel using [uv](https://github.com/astral-sh/uv):
 uv tool install https://github.com/tabletcorry/petrel.git
 ```
 
-This installs the `petrel` command into your uv tools directory.
+This installs the `petrel` command into your uv tools directory. Use
+`petrel --version` to check the installed version.
 
 ## Usage
 

--- a/src/petrel/__init__.py
+++ b/src/petrel/__init__.py
@@ -1,0 +1,5 @@
+"""Petrel package."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/petrel/main.py
+++ b/src/petrel/main.py
@@ -11,6 +11,8 @@ import tempfile
 from importlib import resources
 from typing import TYPE_CHECKING
 
+from . import __version__
+
 if TYPE_CHECKING:
     from importlib.resources.abc import Traversable
 from pathlib import Path
@@ -92,6 +94,7 @@ def ensure_container_running(auto_start: bool = True) -> None:
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
+@click.version_option(__version__)
 @click.pass_context
 def main(ctx: click.Context) -> None:
     """Petrel CLI entry point."""

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,6 +17,7 @@ import pytest
 from click.testing import CliRunner
 
 import petrel.main as main_module
+from petrel import __version__
 from petrel.main import ContainerError, ensure_container_running, main, render_template
 
 
@@ -132,6 +133,13 @@ def test_cli_help() -> None:
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     assert "Usage" in result.output
+
+
+def test_cli_version() -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
 
 
 def test_cli_codex_help() -> None:


### PR DESCRIPTION
## Summary
- expose package version constant
- add `--version` option to CLI
- document the option
- test version output

## Testing
- `uv run ruff check src/petrel tests`
- `uv run mypy src/petrel tests`
- `uv run pytest -q`
- `uv run pre-commit run --files README.md src/petrel/__init__.py src/petrel/main.py tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_686f3c46f5648332b9ed62d923630334