### PR TITLE
Handle container status exit code

### DIFF
--- a/src/petrel/main.py
+++ b/src/petrel/main.py
@@ -63,15 +63,16 @@ def ensure_container_running(auto_start: bool = True) -> None:
         ContainerError: When the subsystem is not running and cannot be started.
     """
     try:
-        status_cp = _run(["container", "system", "status"], capture_output=True)
+        status_cp = _run(
+            ["container", "system", "status"], check=False, capture_output=True
+        )
     except FileNotFoundError as exc:
         raise ContainerError(
             "The 'container' CLI was not found. "
             "Ensure you are running macOS with the new Apple container subsystem."
         ) from exc
 
-    status = status_cp.stdout.strip().lower()
-    if "running" in status:
+    if status_cp.returncode == 0:
         return
 
     if not auto_start:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -77,7 +77,7 @@ def test_ensure_container_running_no_auto_start_when_stopped(
         _cmd: list[str], check: bool = True, capture_output: bool = True
     ) -> DummyCompleted:
         _ = check, capture_output, _cmd
-        return DummyCompleted(stdout="stopped")
+        return DummyCompleted(stdout="stopped", returncode=1)
 
     monkeypatch.setattr(main_module, "_run", fake_run)
     with pytest.raises(ContainerError) as excinfo:
@@ -99,7 +99,7 @@ def test_ensure_container_running_auto_start_success(
         _ = check, capture_output
         calls.append(cmd)
         if cmd[:3] == ["container", "system", "status"]:
-            return DummyCompleted(stdout="stopped")
+            return DummyCompleted(stdout="stopped", returncode=1)
         if cmd[:3] == ["container", "system", "start"]:
             return DummyCompleted(stdout="")
         pytest.skip(f"Unexpected command: {cmd}")
@@ -118,7 +118,7 @@ def test_ensure_container_running_auto_start_failure(
     ) -> DummyCompleted:
         _ = check, capture_output
         if cmd[:3] == ["container", "system", "status"]:
-            return DummyCompleted(stdout="stopped")
+            return DummyCompleted(stdout="stopped", returncode=1)
         raise subprocess.CalledProcessError(returncode=1, cmd=cmd)
 
     monkeypatch.setattr(main_module, "_run", fake_run)


### PR DESCRIPTION
## Summary
- check `container system status` without failing on non-zero exit
- update unit tests for new status logic

## Testing
- `uv run ruff check src tests`
- `uv run mypy src tests`
- `uv run pytest -q`
- `uv run pre-commit run --files src/petrel/main.py tests/test_main.py`

------
https://chatgpt.com/codex/tasks/task_e_6870288d23148332964e5db434aabb65