### PR TITLE
Handle codex version in container builds

### DIFF
--- a/src/petrel/Dockerfile.j2
+++ b/src/petrel/Dockerfile.j2
@@ -22,6 +22,8 @@ RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/instal
 # Put brew on PATH for subsequent layers
 ENV PATH="/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:${PATH}"
 
+ARG CODEX_VERSION="{{ codex_version }}"
+
 RUN brew install codex uv && \
     brew cleanup --prune=all --scrub && \
     rm -rf "$(brew --cache)"


### PR DESCRIPTION
## Summary
- embed Codex version in Dockerfile template
- detect Codex version at runtime and prompt to rebuild outdated images
- tag images with Codex version and `latest`
- add helper to fetch Codex version
- test the new features
- ensure declined rebuild continues with existing container

## Testing
- `uv run ruff format src/petrel/main.py tests/test_main.py`
- `uv run ruff check src/petrel/main.py tests/test_main.py`
- `uv run mypy src/petrel/main.py tests/test_main.py`
- `uv run pytest -q`
- `uv run pre-commit run --files src/petrel/main.py src/petrel/Dockerfile.j2 tests/test_main.py`


------
https://chatgpt.com/codex/tasks/task_e_68702a554e308332b206cd2ba2a9b941